### PR TITLE
Update issue templates and add PR template

### DIFF
--- a/template/.github/ISSUE_TEMPLATE/spike.md
+++ b/template/.github/ISSUE_TEMPLATE/spike.md
@@ -16,19 +16,24 @@ Given above [question/risk/uncertainty], conducting [research/design/investigati
 
 ### Acceptance Criteria
 
-[ACs should be clearly demo-able/verifiable whenever possible. Try specifying them using [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development#Behavioral_specifications).]
+<!-- ACs should be clearly demo-able/verifiable whenever possible. Try specifying them using BDD: https://en.wikipedia.org/wiki/Behavior-driven_development#Behavioral_specifications
+
+---
 
 GIVEN [a contextual precondition] \
   [AND optionally another precondition]
+
 - [ ] WHEN [time box] expires\
   THEN [findings demonstrated] \
   AND [future action is decided] \
   AND [stories covering future action are created if needed]
 
+-->
+
 ### Background
 
-[Any helpful contextual notes or links to artifacts/evidence, if needed]
+<!-- Any helpful contextual notes or links to artifacts/evidence, if needed -->
 
 ### Sketch
 
-[Notes or a checklist reflecting our plan for tackling the uncertainty]
+<!-- Notes or a checklist reflecting our plan for tackling the uncertainty -->

--- a/template/.github/ISSUE_TEMPLATE/user-story.md
+++ b/template/.github/ISSUE_TEMPLATE/user-story.md
@@ -11,10 +11,13 @@ In order to [goal], [stakeholder] wants [change].
 
 ## Acceptance Criteria
 
-<!-- ACs should be clearly demoable/verifiable whenever possible. The template here comes from [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development#Behavioral_specifications), but you aren't required to follow this form. -->
+<!-- ACs should be clearly demo-able/verifiable whenever possible. Try specifying them using BDD: https://en.wikipedia.org/wiki/Behavior-driven_development#Behavioral_specifications
+
+---
 
 GIVEN [a contextual precondition] \
   [AND optionally another precondition]
+
 - [ ] WHEN [a triggering event] happens \
   THEN [a verifiable outcome] \
   [AND optionally another verifiable outcome]
@@ -25,17 +28,12 @@ GIVEN [a contextual precondition] \
 
 ## Security Considerations ([required](https://nvd.nist.gov/800-53/Rev4/control/CM-4))
 
-[comment]: # "Our SSPP says 'The team ensures security implications are considered as part of the agile requirements refinement process by including a section in the issue template used as a basis for new work.' so please don't remove this section without care."
-
-<!--Any security concerns that might be implicated in the change. "None" is OK, just be explicit here! -->
+[comment]: # "Our SSP says 'The team ensures security implications are considered as part of the agile requirements refinement process by including a section in the issue template used as a basis for new work.' so please don't remove this section without care."
+<!-- Any security concerns that might be implicated in the change. "None" is OK, just be explicit here! -->
 
 ---
 
 ## Sketch
 
 <!-- Notes, references, and/or a checklist reflecting our understanding of the selected approach -->
-
-- [ ] First do A
-- [ ] Then do B
-- [ ] Don't forget C
 

--- a/template/.github/pull_request_template.md
+++ b/template/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+Related to [LINK TO ISSUE]
+
+<!-- any pertinent notes -->
+
+<!-- a friendly nonbinding list of reminders, uncomment if you left any undone 
+
+## PR TASKS
+
+- [ ] Included passing tests?
+- [ ] Updated docs, particularly if compliance-sensitive?
+- [ ] Noted any preceding/dependent PRs?
+- [ ] Supplied context for reviewers/testers, whether here or in inline/diff comments?
+-->


### PR DESCRIPTION
Aligns the Copier issue templates with conventions established in [GSA-TTS/pic-blm-cxworks](https://github.com/GSA-TTS/pic-blm-cxworks):

- **Spike & user-story templates:** Use HTML comments for guidance text so instructions are invisible in rendered issues. Wrap the BDD examples in comment blocks so they serve as reference without cluttering new issues.
- **user-story:** Remove placeholder sketch checklist items (`First do A`, `Then do B`, `Don't forget C`).
- **New:** Add `pull_request_template.md` with a standard PR checklist (linked issue, tests, docs, dependencies, reviewer context).

These changes were identified when applying this Copier template to pic-blm-cxworks — the template overwrote existing issue templates with different conventions, requiring manual revert. This PR brings the template in line so future `copier update` runs are non-destructive.