### PR TITLE
Formalize templates

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -14,7 +14,7 @@ _message_after_copy: |
     - SECURITY.md
     - docs/security.md
     - docs/decisions/ (ADR process + template)
-    - .github/ISSUE_TEMPLATE/ (feature, spike, user story)
+    - .github/ISSUE_TEMPLATE/ (feature, enabler, user story, spike, bug report)
 
     IMPORTANT: A .copier-answers.hello-practices.yml file has been created.
     This file is required for future template updates and should be committed

--- a/template/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/template/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report unexpected behavior
+title: '[bug]'
+labels: 'bug'
+assignees: ''
+---
+
+## Bug
+
+[Brief description of the unexpected behavior]
+
+## Steps to reproduce
+
+<!-- Use BDD to make reproduction steps clear and verifiable.
+     https://en.wikipedia.org/wiki/Behavior-driven_development#Behavioral_specifications -->
+
+GIVEN [precondition, e.g., environment, user role, state] \
+  [AND optionally another precondition]
+
+- [ ] WHEN [action taken] \
+  THEN [expected behavior] \
+  BUT [actual behavior observed]
+
+## Severity
+
+<!-- How bad is it? Consider: data loss, security, user-facing, workaround available? -->
+
+## Background
+
+<!-- Screenshots, logs, error messages, links, or any other helpful context -->

--- a/template/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/template/.github/ISSUE_TEMPLATE/bug-report.md
@@ -22,6 +22,17 @@ GIVEN [precondition, e.g., environment, user role, state] \
   THEN [expected behavior] \
   BUT [actual behavior observed]
 
+<!-- Example:
+
+GIVEN I am logged in as a standard user \
+  AND I am on the dashboard page
+
+- [ ] WHEN I click "Export CSV" \
+  THEN a CSV file should download \
+  BUT the page shows a 500 error instead
+
+-->
+
 ## Severity
 
 <!-- How bad is it? Consider: data loss, security, user-facing, workaround available? -->

--- a/template/.github/ISSUE_TEMPLATE/enabler.md
+++ b/template/.github/ISSUE_TEMPLATE/enabler.md
@@ -1,0 +1,48 @@
+---
+name: Enabler
+about: architecture, infrastructure, or compliance work
+title: '[enabler] '
+labels: 'enabler'
+assignees: ''
+---
+
+## [Architecture | Infrastructure | Compliance] work
+
+[System/component] needs [work] so that [benefit/future capability].
+
+## Justification
+
+<!-- Why prioritize this? Note the problem being solved, future value unlocked, or risk being addressed. -->
+
+## Acceptance Criteria
+
+<!-- ACs should be clearly demoable/verifiable whenever possible. Testable ACs
+     support SA-11 (Developer Testing). Try specifying them using
+     BDD: https://en.wikipedia.org/wiki/Behavior-driven_development#Behavioral_specifications
+
+--- For Exploration enablers, use the Spike issue template.
+
+--- For Architecture / Infrastructure / Compliance enablers:
+
+GIVEN [current state of system/component]
+
+- [ ] WHEN [this enabler is complete] \
+  THEN [verifiable outcome] \
+  AND [dependent work is unblocked]
+
+-->
+
+## Dependencies
+
+<!-- Other features or enablers that depend on or block this work. "None" is fine. -->
+
+## Security Considerations
+
+<!-- CM-4 · SA-8 (Security Engineering Principles): Enablers that affect system
+     boundary, data handling, authentication, or architecture should note security
+     implications. "None" is fine.
+     https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_2_0/home?element=CM-04 -->
+
+## Background
+
+<!-- Any helpful contextual notes or links to artifacts/evidence, if needed -->

--- a/template/.github/ISSUE_TEMPLATE/enabler.md
+++ b/template/.github/ISSUE_TEMPLATE/enabler.md
@@ -8,11 +8,11 @@ assignees: ''
 
 ## [Architecture | Infrastructure | Compliance] work
 
-[System/component] needs [work] so that [benefit/future capability].
+[System|component] needs [work] so that [benefit-enabled|risk-averted].
 
 ## Justification
 
-<!-- Why prioritize this? Note the problem being solved, future value unlocked, or risk being addressed. -->
+<!-- Why would someone prioritize this? Note the problem being solved, future value unlocked, or risk being addressed. -->
 
 ## Acceptance Criteria
 
@@ -24,17 +24,20 @@ assignees: ''
 
 --- For Architecture / Infrastructure / Compliance enablers:
 
-GIVEN [current state of system/component]
+GIVEN [system|component] currently [has limitation|risk]
 
-- [ ] WHEN [this enabler is complete] \
-  THEN [verifiable outcome] \
-  AND [dependent work is unblocked]
+- [ ] WHEN this enabler is complete \
+  THEN [measurable improvement] \
+  AND [downstream work] is unblocked
 
 -->
 
+<!-- 
 ## Dependencies
 
-<!-- Other features or enablers that depend on or block this work. "None" is fine. -->
+Other features or enablers that depend on or block this work. "None" is fine. 
+
+-->
 
 ## Security Considerations
 

--- a/template/.github/ISSUE_TEMPLATE/feature.md
+++ b/template/.github/ISSUE_TEMPLATE/feature.md
@@ -1,12 +1,14 @@
 ---
 name: Feature
 about: Higher-level, roadmap-worthy epic
-title: ''
-labels: ''
+title: '[feature] '
+labels: 'feature'
 assignees: ''
 ---
 
-[NOTE: For individual stories, [use the user story template](https://github.com/gsa/data.gov/issues/new?assignees=&labels=&template=user-story.md&title=)! Only use this template for larger things that will likely break down into a series of smaller stories over time.]
+<!-- NOTE: For individual stories, use the User Story issue template! Only use
+     this template for larger things that will likely break down into a series of
+     smaller stories over time. -->
 
 ## Feature/what we're after
 
@@ -20,6 +22,13 @@ assignees: ''
 ## Measurements/metrics
 
 - [description of a thing that can be monitored or tested to measure and validate when the outcome has been achieved]
+
+## Security Considerations
+
+<!-- CM-4 · SA-8 (Security Engineering Principles): Features that affect system
+     boundary, data handling, authentication, or architecture should note security
+     implications early — they'll flow down into every story. "None" is fine.
+     https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_2_0/home?element=CM-04 -->
 
 ## References/background
 

--- a/template/.github/ISSUE_TEMPLATE/spike.md
+++ b/template/.github/ISSUE_TEMPLATE/spike.md
@@ -24,7 +24,7 @@ GIVEN [a contextual precondition] \
 - [ ] WHEN [time box] expires\
   THEN [findings demonstrated] \
   AND [future action is demoed/decided] \
-  AND [security implications of findings are noted] \ <!-- RA-3 (Risk Assessment) · SR-3 (Supply Chain Protection) -->
+  AND [security implications of findings are noted] \ <!-- RA-3 (Risk Assessment) · SR-3 (Supply Chain Protection)
   AND [stories covering future action are created if needed]
 
 -->

--- a/template/.github/ISSUE_TEMPLATE/spike.md
+++ b/template/.github/ISSUE_TEMPLATE/spike.md
@@ -1,8 +1,8 @@
 ---
 name: Spike 
 about: Research, design, investigate, prototype
-title: ''
-labels: ''
+title: '[spike] '
+labels: 'spike'
 assignees: ''
 ---
 
@@ -10,9 +10,7 @@ assignees: ''
 
 We want to [goal], but we're not sure how to do that.
 
-Given above [question/risk/uncertainty], conducting [research/design/investigation/prototyping] is needed to provide factual knowledge on future steps.
-
-[timebox] of effort has been allocated and once compete, findings will be demonstrated and specific future actions will be decided.
+We're spending a pre-determined timebox [research/design/investigation/prototyping] to provide factual knowledge to guide future steps.
 
 ### Acceptance Criteria
 
@@ -25,7 +23,8 @@ GIVEN [a contextual precondition] \
 
 - [ ] WHEN [time box] expires\
   THEN [findings demonstrated] \
-  AND [future action is decided] \
+  AND [future action is demoed/decided] \
+  AND [security implications of findings are noted] \ <!-- RA-3 (Risk Assessment) · SR-3 (Supply Chain Protection) -->
   AND [stories covering future action are created if needed]
 
 -->

--- a/template/.github/ISSUE_TEMPLATE/user-story.md
+++ b/template/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,8 +1,8 @@
 ---
 name: User story
-about: Story about a new user feature
-title: ''
-labels: ''
+about: Story about a user-facing change
+title: '[story] '
+labels: 'story'
 assignees: ''
 ---
 ## User Story
@@ -11,7 +11,9 @@ In order to [goal], [stakeholder] wants [change].
 
 ## Acceptance Criteria
 
-<!-- ACs should be clearly demo-able/verifiable whenever possible. Try specifying them using BDD: https://en.wikipedia.org/wiki/Behavior-driven_development#Behavioral_specifications
+<!-- ACs should be clearly demoable/verifiable whenever possible. Testable ACs
+     support SA-11 (Developer Testing). Try specifying them using
+     BDD: https://en.wikipedia.org/wiki/Behavior-driven_development#Behavioral_specifications
 
 ---
 
@@ -26,7 +28,7 @@ GIVEN [a contextual precondition] \
 
 <!-- Any helpful contextual notes or links to artifacts/evidence, if needed -->
 
-## Security Considerations ([required](https://nvd.nist.gov/800-53/Rev4/control/CM-4))
+## Security Considerations ([required](https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_2_0/home?element=CM-04))
 
 [comment]: # "Our SSP says 'The team ensures security implications are considered as part of the agile requirements refinement process by including a section in the issue template used as a basis for new work.' so please don't remove this section without care."
 <!-- Any security concerns that might be implicated in the change. "None" is OK, just be explicit here! -->

--- a/template/.github/pull_request_template.md
+++ b/template/.github/pull_request_template.md
@@ -1,13 +1,47 @@
-Related to [LINK TO ISSUE]
+Related to #[ISSUE]
 
-<!-- any pertinent notes -->
+## What changed?
 
-<!-- a friendly nonbinding list of reminders, uncomment if you left any undone 
+<!-- Briefly describe the change and its motivation. -->
 
-## PR TASKS
-
-- [ ] Included passing tests?
-- [ ] Updated docs, particularly if compliance-sensitive?
-- [ ] Noted any preceding/dependent PRs?
-- [ ] Supplied context for reviewers/testers, whether here or in inline/diff comments?
+<!--
+## Additional context
+- Notable preceding/dependent PRs
+- Additional context/references for reviewers/testers other than referenced issue
 -->
+
+## Security impact
+
+<!-- CM-4 (Security & Privacy Impact Analysis): 
+     Federal policy requires assessing every change for security impact. 
+       * "None expected" is fine for routine changes, so it's pre-filled. 
+       * For changes that affect system boundary, data handling, authentication, access
+         control, or architecture, you likely need to link to a full Security Impact
+         Analysis (SIA) similar to this template: 
+         https://docs.google.com/document/d/15Lh4N3grZk-Lq7W2z0Y7u6j4zyUvrljtofXbh-WKpAo/edit 
+     Verify that any Security Considerations noted in the linked issue are addressed -->
+
+None expected.
+
+## Checklist
+
+<!-- These items support continuous ATO readiness. The NIST SP 800-53 Rev 5 control
+     IDs in the comments show what each item satisfies — removing them may affect
+     your compliance posture. -->
+
+- [ ] Tests for these changes added (when possible) <!-- SA-11 Developer Testing · SI-7 Software & Information Integrity -->
+- [ ] Relevant docs updated <!-- SA-5 System Documentation · CM-3 Configuration Change Control -->
+- [ ] No new third-party dependencies (or changes reviewed) <!-- SR-3 Supply Chain Protection · RA-5 Vulnerability Monitoring -->
+- [ ] No new PII or sensitive data handling (or documented) <!-- SI-12 Information Management · PT-2 Authority to Process PII -->
+
+### AI disclosure
+
+<!-- SA-15 (Development Process, Standards, and Tools): GSA policy requires
+     transparency about AI tool usage. -->
+
+Check one.
+
+- [ ] No AI tools used
+- [ ] AI-assisted — I understand all changes and could maintain them without AI
+
+<!-- Optional: note which tools and modes (e.g., Foo completions, Bar chat, Baz coding agent) -->

--- a/template/.github/pull_request_template.md
+++ b/template/.github/pull_request_template.md
@@ -31,7 +31,7 @@ None expected.
 
 - [ ] Tests for these changes added (when possible) <!-- SA-11 Developer Testing · SI-7 Software & Information Integrity -->
 - [ ] Relevant docs updated <!-- SA-5 System Documentation · CM-3 Configuration Change Control -->
-- [ ] No new third-party dependencies (or changes reviewed) <!-- SR-3 Supply Chain Protection · RA-5 Vulnerability Monitoring -->
+- [ ] Newly introduced dependencies were reviewed for security posture and compatible licensing, and are actively updated <!-- SR-3 Supply Chain Protection · RA-5 Vulnerability Monitoring -->
 - [ ] No new PII or sensitive data handling (or documented) <!-- SI-12 Information Management · PT-2 Authority to Process PII -->
 
 ### AI disclosure
@@ -41,7 +41,9 @@ None expected.
 
 Check one.
 
-- [ ] No AI tools used
-- [ ] AI-assisted — I understand all changes and could maintain them without AI
+- [ ] I did not use AI tools.
+- [ ] I drove, AI tools assisted: I used AI tools, but I was in the driver's seat. (Please indicate when changes were heavily reliant.)
+- [ ] AI tools drove, I assisted: These changes were primarily implemented by AI tools, but I can explain, defend, and maintain all the changes.
+- [ ] AI tools drove without much assistance: These are changes that would be difficult to maintain without AI tools. (Note that PRs of this nature will be more heavily scrutinized.)
 
 <!-- Optional: note which tools and modes (e.g., Foo completions, Bar chat, Baz coding agent) -->


### PR DESCRIPTION
Since templates are part of the compliance story, I wanted to formalize ours a little bit and decorate templates with control references. I'm doing it in `hello-practices` to help set up consistency across TTS. (Once changes are merged here and then tagged for release, we'll get a PR to update these in our downstream repositories that use the template.)

* The PR template in particular is triangulating across all of the compliance concerns mentioned in #3. 
* I tried to keep them succinct, friendly, and consistent with each other, and to minimize the editing needed to get a clean result post-submission; only required stuff is outside of comments.
* I prefer stories to be _about users_. I added the "enabler" template to leave us a way to track non-user-facing work we do without conflating the two. This is also helpful in the long term for distinguishing donkey-work from value-delivery. ("Enabler" is a SAFe concept if you want to look it up. I still kept spikes separate because they are pretty different.)

What d'yall think?